### PR TITLE
Support Sigstore custom claims

### DIFF
--- a/.github/workflows/sigstore-enrollment-sync.yml
+++ b/.github/workflows/sigstore-enrollment-sync.yml
@@ -17,26 +17,22 @@ on:
         type: string
         required: false
         default: "20"
-      webcat_path:
+      enrollment_path:
         type: string
         required: false
-        default: ".well-known/webcat/"
-      enrollment_file:
+        default: ".well-known/webcat/enrollment.json"
+      enrollment_prev_path:
         type: string
         required: false
-        default: "enrollment.json"
-      enrollment_prev_file:
+        default: ".well-known/webcat/enrollment-prev.json"
+      bundle_path:
         type: string
         required: false
-        default: "enrollment-prev.json"
-      bundle_file:
+        default: ".well-known/webcat/bundle.json"
+      bundle_prev_path:
         type: string
         required: false
-        default: "bundle.json"
-      bundle_prev_file:
-        type: string
-        required: false
-        default: "bundle-prev.json"
+        default: ".well-known/webcat/bundle-prev.json"
 
 
 permissions:
@@ -79,10 +75,10 @@ jobs:
           IDENTITY: ${{ inputs.identity }}
           MAX_AGE: ${{ inputs.max_age }}
           WEBCAT_PATH: ${{ inputs.webcat_path }}
-          ENROLLMENT_PATH: ${{ inputs.webcat_path }}${{ inputs.enrollment_file }}
-          ENROLLMENT_PREV_PATH: ${{ inputs.webcat_path }}${{ inputs.enrollment_prev_file }}
-          BUNDLE_PATH: ${{ inputs.webcat_path }}${{ inputs.bundle_file }}
-          BUNDLE_PREV_PATH: ${{ inputs.webcat_path }}${{ inputs.bundle_prev_file }}
+          ENROLLMENT_PATH: ${{ inputs.webcat_path }}${{ inputs.enrollment_path }}
+          ENROLLMENT_PREV_PATH: ${{ inputs.webcat_path }}${{ inputs.enrollment_prev_path }}
+          BUNDLE_PATH: ${{ inputs.webcat_path }}${{ inputs.bundle_path }}
+          BUNDLE_PREV_PATH: ${{ inputs.webcat_path }}${{ inputs.bundle_prev_path }}
         run: |
           set -euo pipefail
 
@@ -126,7 +122,7 @@ jobs:
           ISSUER: ${{ inputs.issuer }}
           IDENTITY: ${{ inputs.identity }}
           MAX_AGE: ${{ inputs.max_age }}
-          ENROLLMENT_PATH: ${{ inputs.webcat_path }}/${{ inputs.enrollment_file }}
+          ENROLLMENT_PATH: ${{ inputs.webcat_path }}/${{ inputs.enrollment_path }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/sigstore-enrollment-sync.yml
+++ b/.github/workflows/sigstore-enrollment-sync.yml
@@ -3,37 +3,149 @@ name: Sync Sigstore Enrollment
 on:
   workflow_call:
     inputs:
-      issuer:
+      # Source repository
+      source-repository-uri:
+        description: "OID 1.3.6.1.4.1.57264.1.12"
         type: string
-        required: true
-      identity:
+        required: true  
+
+      # This is defaulted to this repository for this workflow to be invoked directly
+      # from a third party one.
+      build-signer-uri:
+        description: "OID 1.3.6.1.4.1.57264.1.9"
         type: string
-        required: true
+        required: false
+        default: "https://github.com/freedomofpress/webcat-cli/.github/workflows/webcat-generate-and-commit-manifest.yml@refs/heads/main"
+
+      # Github default
+      issuer-v2:
+        description: "Fulcio Issuer V2 (OID 1.3.6.1.4.1.57264.1.8)"
+        type: string
+        required: false
+        default: "https://token.actions.githubusercontent.com"
+
       max_age:
+        description: "Maximum enrollment validity in seconds"
         type: string
         required: false
-        default: "15552000"
-      node_version:
-        type: string
-        required: false
-        default: "20"
+        default: "15552000" # 180 days
+
       enrollment_path:
+        description: "Path to enrollment.json"
         type: string
         required: false
         default: ".well-known/webcat/enrollment.json"
+
       enrollment_prev_path:
+        description: "Path to enrollment-prev.json"
         type: string
         required: false
         default: ".well-known/webcat/enrollment-prev.json"
+
       bundle_path:
+        description: "Path to bundle.json"
         type: string
         required: false
         default: ".well-known/webcat/bundle.json"
+
       bundle_prev_path:
+        description: "Path to bundle-prev.json"
         type: string
         required: false
         default: ".well-known/webcat/bundle-prev.json"
 
+      node_version:
+        description: "Node.js version for webcat-cli"
+        type: string
+        required: false
+        default: "20"
+
+      issuer-v1:
+        description: "Fulcio Issuer V1 (OID 1.3.6.1.4.1.57264.1.1)"
+        type: string
+        required: false
+        default: "https://token.actions.githubusercontent.com"
+
+      build-signer-digest:
+        description: "OID 1.3.6.1.4.1.57264.1.10"
+        type: string
+        required: false
+
+      runner-environment:
+        description: "OID 1.3.6.1.4.1.57264.1.11"
+        type: string
+        required: false
+        default: "github-hosted"
+
+      source-repository-digest:
+        description: "OID 1.3.6.1.4.1.57264.1.13"
+        type: string
+        required: false
+
+      source-repository-ref:
+        description: "OID 1.3.6.1.4.1.57264.1.14"
+        type: string
+        default: "refs/heads/main"
+        required: true
+
+      source-repository-identifier:
+        description: "OID 1.3.6.1.4.1.57264.1.15"
+        type: string
+        required: false
+
+      source-repository-owner-uri:
+        description: "OID 1.3.6.1.4.1.57264.1.16"
+        type: string
+        required: false
+
+      source-repository-owner-identifier:
+        description: "OID 1.3.6.1.4.1.57264.1.17"
+        type: string
+        required: false
+
+      build-config-uri:
+        description: "OID 1.3.6.1.4.1.57264.1.18"
+        type: string
+        required: false
+
+      build-config-digest:
+        description: "OID 1.3.6.1.4.1.57264.1.19"
+        type: string
+        required: false
+
+      build-trigger:
+        description: "OID 1.3.6.1.4.1.57264.1.20"
+        type: string
+        required: false
+
+      run-invocation-uri:
+        description: "OID 1.3.6.1.4.1.57264.1.21"
+        type: string
+        required: false
+
+      source-repository-visibility-at-signing:
+        description: "OID 1.3.6.1.4.1.57264.1.22"
+        type: string
+        required: false
+
+      deployment-environment:
+        description: "OID 1.3.6.1.4.1.57264.1.23"
+        type: string
+        required: false
+
+      # --------------------------------------------------
+      # Arbitrary Custom OID Constraints
+      # --------------------------------------------------
+
+      custom-claims:
+        description: |
+          Additional custom OID claims.
+          Format: one per line, oid=value
+          Example:
+            1.2.3.4.5=test
+            1.3.6.1.4.1.57264.1.99=experimental
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -71,44 +183,81 @@ jobs:
       - name: Generate sigstore enrollment
         id: enrollment
         env:
-          ISSUER: ${{ inputs.issuer }}
-          IDENTITY: ${{ inputs.identity }}
           MAX_AGE: ${{ inputs.max_age }}
-          WEBCAT_PATH: ${{ inputs.webcat_path }}
-          ENROLLMENT_PATH: ${{ inputs.webcat_path }}${{ inputs.enrollment_path }}
-          ENROLLMENT_PREV_PATH: ${{ inputs.webcat_path }}${{ inputs.enrollment_prev_path }}
-          BUNDLE_PATH: ${{ inputs.webcat_path }}${{ inputs.bundle_path }}
-          BUNDLE_PREV_PATH: ${{ inputs.webcat_path }}${{ inputs.bundle_prev_path }}
+          ENROLLMENT_PATH: ${{ inputs.enrollment_path }}
+          ENROLLMENT_PREV_PATH: ${{ inputs.enrollment_prev_path }}
+          BUNDLE_PATH: ${{ inputs.bundle_path }}
+          BUNDLE_PREV_PATH: ${{ inputs.bundle_prev_path }}
         run: |
           set -euo pipefail
 
           tmp_file="$(mktemp)"
 
-          mkdir -p "$WEBCAT_PATH"
+          args=()
 
-          npx tsx webcat-cli/src/cli.ts enrollment create \
+          add_flag () {
+            local flag="$1"
+            local value="$2"
+            if [ -n "$value" ]; then
+              args+=("$flag" "$value")
+            fi
+          }
+
+          # Issuer
+          add_flag "--issuer-v2" "${{ inputs.issuer-v2 }}"
+          add_flag "--issuer-v1" "${{ inputs.issuer-v1 }}"
+
+          # Signer claims
+          add_flag "--build-signer-uri" "${{ inputs.build-signer-uri }}"
+          add_flag "--build-signer-digest" "${{ inputs.build-signer-digest }}"
+          add_flag "--runner-environment" "${{ inputs.runner-environment }}"
+          add_flag "--run-invocation-uri" "${{ inputs.run-invocation-uri }}"
+
+          # Repository claims
+          add_flag "--source-repository-uri" "${{ inputs.source-repository-uri }}"
+          add_flag "--source-repository-digest" "${{ inputs.source-repository-digest }}"
+          add_flag "--source-repository-ref" "${{ inputs.source-repository-ref }}"
+          add_flag "--source-repository-identifier" "${{ inputs.source-repository-identifier }}"
+          add_flag "--source-repository-owner-uri" "${{ inputs.source-repository-owner-uri }}"
+          add_flag "--source-repository-owner-identifier" "${{ inputs.source-repository-owner-identifier }}"
+          add_flag "--source-repository-visibility-at-signing" "${{ inputs.source-repository-visibility-at-signing }}"
+
+          # Build config claims
+          add_flag "--build-config-uri" "${{ inputs.build-config-uri }}"
+          add_flag "--build-config-digest" "${{ inputs.build-config-digest }}"
+          add_flag "--build-trigger" "${{ inputs.build-trigger }}"
+
+          # Deployment claim
+          add_flag "--deployment-environment" "${{ inputs.deployment-environment }}"
+
+          # Custom arbitrary OID claims
+          if [ -n "${{ inputs.custom-claims }}" ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              args+=("--claim" "$line")
+            done <<< "${{ inputs.custom-claims }}"
+          fi
+
+          node webcat-cli/dist/cli.cjs enrollment create \
             --type sigstore \
             --community-trusted-root \
-            --issuer "$ISSUER" \
-            --identity "$IDENTITY" \
             --max-age "$MAX_AGE" \
+            "${args[@]}" \
             --output "$tmp_file"
 
-          # Fresh start: no existing enrollment
+          # Diff logic
           if [ ! -f "$ENROLLMENT_PATH" ]; then
             mv "$tmp_file" "$ENROLLMENT_PATH"
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Existing enrollment: check for changes
           if cmp -s "$tmp_file" "$ENROLLMENT_PATH"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             rm -f "$tmp_file"
             exit 0
           fi
 
-          # Save previous version
           cp "$ENROLLMENT_PATH" "$ENROLLMENT_PREV_PATH"
           [ -f "$BUNDLE_PATH" ] && cp "$BUNDLE_PATH" "$BUNDLE_PREV_PATH"
 
@@ -119,10 +268,10 @@ jobs:
       - name: Prepare pull request details
         if: steps.enrollment.outputs.changed == 'true'
         env:
-          ISSUER: ${{ inputs.issuer }}
-          IDENTITY: ${{ inputs.identity }}
+          ISSUER_V2: ${{ inputs.issuer-v2 }}
+          ISSUER_V1: ${{ inputs.issuer-v1 }}
           MAX_AGE: ${{ inputs.max_age }}
-          ENROLLMENT_PATH: ${{ inputs.webcat_path }}/${{ inputs.enrollment_path }}
+          ENROLLMENT_PATH: ${{ inputs.enrollment_path }}
         run: |
           set -euo pipefail
 
@@ -131,16 +280,45 @@ jobs:
           {
             echo "## Sigstore enrollment update"
             echo
-            echo "- Issuer: $ISSUER"
-            echo "- Identity: $IDENTITY"
+
+            echo "### Issuer"
+            [ -n "$ISSUER_V2" ] && echo "- Fulcio Issuer V2: $ISSUER_V2"
+            [ -n "$ISSUER_V1" ] && echo "- Fulcio Issuer V1: $ISSUER_V1"
+            echo
+
+            echo "### Signer Constraints"
+            [ -n "${{ inputs.build-signer-uri }}" ] && \
+              echo "- Build Signer URI: ${{ inputs.build-signer-uri }}"
+            [ -n "${{ inputs.build-signer-digest }}" ] && \
+              echo "- Build Signer Digest: ${{ inputs.build-signer-digest }}"
+            [ -n "${{ inputs.runner-environment }}" ] && \
+              echo "- Runner Environment: ${{ inputs.runner-environment }}"
+            [ -n "${{ inputs.run-invocation-uri }}" ] && \
+              echo "- Run Invocation URI: ${{ inputs.run-invocation-uri }}"
+            echo
+
+            echo "### Repository Constraints"
+            [ -n "${{ inputs.source-repository-uri }}" ] && \
+              echo "- Repository URI: ${{ inputs.source-repository-uri }}"
+            [ -n "${{ inputs.source-repository-ref }}" ] && \
+              echo "- Ref: ${{ inputs.source-repository-ref }}"
+            [ -n "${{ inputs.source-repository-digest }}" ] && \
+              echo "- Repository Digest: ${{ inputs.source-repository-digest }}"
+            echo
+
+            echo "### Other Constraints"
+            [ -n "${{ inputs.deployment-environment }}" ] && \
+              echo "- Deployment Environment: ${{ inputs.deployment-environment }}"
             echo "- Max age: $MAX_AGE"
             echo
+
             echo "### Diff"
             echo
-            echo "```diff"
+            echo '```diff'
             git diff -- "$ENROLLMENT_PATH"
-            echo "```"
+            echo '```'
           } > "$PR_BODY"
+
 
       # 7. Open or update a single rolling PR
       - name: Open pull request
@@ -153,4 +331,7 @@ jobs:
           branch: "chore/update-sigstore-enrollment"
           delete-branch: false
           add-paths: |
-            ${{ inputs.webcat_path }}
+            ${{ inputs.enrollment_path }}
+            ${{ inputs.enrollment_prev_path }}
+            ${{ inputs.bundle_path }}
+            ${{ inputs.bundle_prev_path }}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To learn more about Sigsum and how to write a policy, see Sigsum's [_Getting Sta
 If you choose Sigstore, WEBCAT provides GitHub Actions that support automated deployments.
 
 > [!WARNING]
-> Sigstore support is still a work in progress. Custom claims are not yet supported, but will be added soon.
+> Sigstore support is still a work in progress. Claim-based enrollment constraints are supported.
 
 In theory, WEBCAT also supports a bring-your-own Sigstore deployment. This is not documented here due to its complexity. This guide assumes you are using the Sigstore [_Public Good_ instance](https://openssf.org/blog/2023/10/03/running-sigstore-as-a-managed-service-a-tour-of-sigstores-public-good-instance/), the same one used by GitHub and public container registries.
 
@@ -75,7 +75,7 @@ The Sigstore workflow consists of two actions:
     *(This submission step will soon be integrated directly into the CLI.)*
 
 > [!CAUTION]
-> Currently, verification is based on the GitHub workflow identity (workflow name). This has known security limitations until custom claims are supported, but is acceptable while WEBCAT is in alpha.
+> Sigstore enrollments support claim-based constraints using certificate extension OIDs.
 
 * Manifest Update Action - [Example Usage](https://github.com/freedomofpress/webcat-demo-test/blob/main/.github/workflows/generate-sign-sigstore-manifest.yaml)
 
@@ -122,8 +122,9 @@ go install sigsum.org/sigsum-go/cmd/sigsum-submit@latest
 ## Enrollment helpers
 
 The `enrollment` namespace manages Sigsum or Sigstore enrollment payloads. Sigsum enrollments
-are the default; use `--type sigstore` along with `--issuer`, `--identity`, and either
-`--trusted-root` or `--community-trusted-root` to build Sigstore enrollments.
+are the default; use `--type sigstore` along with Sigstore claim constraints (`--claim`
+and/or compatibility flags `--issuer` + `--identity`) and either `--trusted-root` or
+`--community-trusted-root` to build Sigstore enrollments.
 
 | Command | Purpose |
 | --- | --- |
@@ -142,6 +143,19 @@ The canonicalized document (useful for audits) can be produced with:
 
 ```sh
 npx tsx src/cli.ts enrollment canonicalize -i examples/enrollment.json
+```
+
+Sigstore enrollment example with claims (legacy `--identity` and `--issuer` are mapped to claims):
+
+```sh
+npx tsx src/cli.ts enrollment create \
+  --type sigstore \
+  --community-trusted-root \
+  --identity alice@example.com \
+  --issuer https://token.actions.githubusercontent.com \
+  --build-signer-uri https://github.com/acme/repo/.github/workflows/release.yml@refs/heads/main \
+  --claim 1.3.6.1.4.1.57264.1.11=platform-hosted \
+  --max-age 3600
 ```
 
 ## Manifest helpers

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -368,148 +368,36 @@ enrollment
   .option("--issuer <value>", "Sigstore issuer (maps to OID 1.3.6.1.4.1.57264.1.8)")
   .option("--identity <value>", "Sigstore identity (maps to OID 2.5.29.17)")
   .option("--claim <oid=value>", "Sigstore claim constraint by OID", collectClaim, [] as SigstoreClaimOption[])
-  .option(
-    "--subject-alt-name <value>",
-    "Sigstore claim OID 2.5.29.17 (Subject Alternative Name)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.subjectAltName, value),
-  )
-  .option(
-    "--issuer-v1 <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.1 (Fulcio Issuer V1)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.issuerV1, value),
-  )
-  .option(
-    "--issuer-v2 <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.8 (Fulcio Issuer V2)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.issuerV2, value),
-  )  
-  .option(
-    "--build-signer-uri <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.9",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildSignerUri, value),
-  )
-  .option(
-    "--build-signer-digest <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.10",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildSignerDigest, value),
-  )
-  .option(
-    "--runner-environment <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.11",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.runnerEnvironment, value),
-  )
-  .option(
-    "--source-repository-uri <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.12",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryUri, value),
-  )
-  .option(
-    "--source-repository-digest <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.13",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryDigest, value),
-  )
-  .option(
-    "--source-repository-ref <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.14",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryRef, value),
-  )
-  .option(
-    "--source-repository-identifier <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.15",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryIdentifier, value),
-  )
-  .option(
-    "--source-repository-owner-uri <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.16",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryOwnerUri, value),
-  )
-  .option(
-    "--source-repository-owner-identifier <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.17",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryOwnerIdentifier, value),
-  )
-  .option(
-    "--build-config-uri <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.18",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildConfigUri, value),
-  )
-  .option(
-    "--build-config-digest <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.19",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildConfigDigest, value),
-  )
-  .option(
-    "--build-trigger <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.20",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildTrigger, value),
-  )
-  .option(
-    "--run-invocation-uri <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.21",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.runInvocationUri, value),
-  )
-  .option(
-    "--source-repository-visibility-at-signing <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.22",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryVisibilityAtSigning, value),
-  )
-  .option(
-    "--deployment-environment <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.23",
-    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.deploymentEnvironment, value),
-  )
-  .option(
-    "--workflow-trigger-legacy <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.2 (Legacy Workflow Trigger)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowTriggerLegacy, value),
-  )
+  .option("--source-repository-uri <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.12")
+  .option("--source-repository-digest <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.13")
+  .option("--source-repository-ref <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.14")
+  .option("--source-repository-identifier <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.15")
+  .option("--source-repository-owner-uri <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.16")
+  .option("--source-repository-owner-identifier <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.17")
 
-  .option(
-    "--workflow-sha-legacy <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.3 (Legacy Workflow SHA)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowShaLegacy, value),
-  )
+  .option("--build-signer-uri <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.9")
+  .option("--build-signer-digest <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.10")
+  .option("--runner-environment <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.11")
 
-  .option(
-    "--workflow-name-legacy <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.4 (Legacy Workflow Name)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowNameLegacy, value),
-  )
+  .option("--build-config-uri <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.18")
+  .option("--build-config-digest <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.19")
 
-  .option(
-    "--workflow-repository-legacy <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.5 (Legacy Workflow Repository)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowRepositoryLegacy, value),
-  )
+  .option("--build-trigger <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.20")
+  .option("--run-invocation-uri <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.21")
+  .option("--source-repository-visibility-at-signing <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.22")
+  .option("--deployment-environment <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.23")
 
-  .option(
-    "--workflow-ref-legacy <value>",
-    "Sigstore claim OID 1.3.6.1.4.1.57264.1.6 (Legacy Workflow Ref)",
-    (value: string, previous: SigstoreClaimOption[]) =>
-      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowRefLegacy, value),
-  )
+  .option("--issuer-v1 <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.1")
+  .option("--issuer-v2 <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.8")
+  .option("--subject-alt-name <value>", "Sigstore claim OID 2.5.29.17")
+
+  .option("--workflow-trigger-legacy <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.2")
+  .option("--workflow-sha-legacy <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.3")
+  .option("--workflow-name-legacy <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.4")
+  .option("--workflow-repository-legacy <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.5")
+  .option("--workflow-ref-legacy <value>", "Sigstore claim OID 1.3.6.1.4.1.57264.1.6")
   .option("-o, --output <path>", "Write result to file instead of stdout")
-  .action(async (options: {
-    policyFile?: string;
-    signer: string[];
-    threshold?: number | string;
-    maxAge?: number | string;
-    casUrl?: string;
-    type?: string;
-    trustedRoot?: string;
-    communityTrustedRoot?: boolean;
-    issuer?: string;
-    identity?: string;
-    claim: SigstoreClaimOption[];
-    output?: string;
-  }) => {
+  .action(async (options: any) => {
     const enrollmentType = options.type ?? "sigsum";
     if (enrollmentType !== "sigsum" && enrollmentType !== "sigstore") {
       throw new Error("enrollment type must be 'sigsum' or 'sigstore'");
@@ -565,12 +453,47 @@ enrollment
         throw new Error("--max-age is required for sigstore enrollments");
       }
       const claims: SigstoreClaimOption[] = [...(options.claim ?? [])];
-      if (options.identity) {
-        setClaim(claims, SIGSTORE_CLAIM_OIDS.subjectAltName, options.identity);
-      }
-      if (options.issuer) {
-        setClaim(claims, SIGSTORE_CLAIM_OIDS.issuerV2, options.issuer);
-      }
+
+      // helper
+      const add = (oid: string, value?: string) => {
+        if (value) {
+          claims.push({ oid, value: String(value).trim() });
+        }
+      };
+
+      // baseline
+      add(SIGSTORE_CLAIM_OIDS.subjectAltName, options.identity);
+      add(SIGSTORE_CLAIM_OIDS.subjectAltName, options.subjectAltName);
+
+      add(SIGSTORE_CLAIM_OIDS.issuerV2, options.issuerV2 ?? options.issuer);
+      add(SIGSTORE_CLAIM_OIDS.issuerV1, options.issuerV1);
+
+      // structured OIDs
+      add(SIGSTORE_CLAIM_OIDS.buildSignerUri, options.buildSignerUri);
+      add(SIGSTORE_CLAIM_OIDS.buildSignerDigest, options.buildSignerDigest);
+      add(SIGSTORE_CLAIM_OIDS.runnerEnvironment, options.runnerEnvironment);
+
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryUri, options.sourceRepositoryUri);
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryDigest, options.sourceRepositoryDigest);
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryRef, options.sourceRepositoryRef);
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryIdentifier, options.sourceRepositoryIdentifier);
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryOwnerUri, options.sourceRepositoryOwnerUri);
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryOwnerIdentifier, options.sourceRepositoryOwnerIdentifier);
+
+      add(SIGSTORE_CLAIM_OIDS.buildConfigUri, options.buildConfigUri);
+      add(SIGSTORE_CLAIM_OIDS.buildConfigDigest, options.buildConfigDigest);
+
+      add(SIGSTORE_CLAIM_OIDS.buildTrigger, options.buildTrigger);
+      add(SIGSTORE_CLAIM_OIDS.runInvocationUri, options.runInvocationUri);
+      add(SIGSTORE_CLAIM_OIDS.sourceRepositoryVisibilityAtSigning, options.sourceRepositoryVisibilityAtSigning);
+      add(SIGSTORE_CLAIM_OIDS.deploymentEnvironment, options.deploymentEnvironment);
+
+      add(SIGSTORE_CLAIM_OIDS.workflowTriggerLegacy, options.workflowTriggerLegacy);
+      add(SIGSTORE_CLAIM_OIDS.workflowShaLegacy, options.workflowShaLegacy);
+      add(SIGSTORE_CLAIM_OIDS.workflowNameLegacy, options.workflowNameLegacy);
+      add(SIGSTORE_CLAIM_OIDS.workflowRepositoryLegacy, options.workflowRepositoryLegacy);
+      add(SIGSTORE_CLAIM_OIDS.workflowRefLegacy, options.workflowRefLegacy);
+
       if (claims.length === 0) {
         throw new Error(
           "at least one sigstore claim is required (use --claim and/or --identity/--issuer)",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,47 @@ const SIGSTORE_OIDC_ISSUER = "https://oauth2.sigstore.dev/auth";
 const SIGSTORE_OIDC_CLIENT_ID = "sigstore";
 const SIGSTORE_OIDC_SCOPE = "openid email";
 
+export const SIGSTORE_CLAIM_OIDS = {
+  // Standard X.509
+  subjectAltName: "2.5.29.17",
+
+  // Fulcio base
+  issuerV1: "1.3.6.1.4.1.57264.1.1",
+  workflowTriggerLegacy: "1.3.6.1.4.1.57264.1.2",
+  workflowShaLegacy: "1.3.6.1.4.1.57264.1.3",
+  workflowNameLegacy: "1.3.6.1.4.1.57264.1.4",
+  workflowRepositoryLegacy: "1.3.6.1.4.1.57264.1.5",
+  workflowRefLegacy: "1.3.6.1.4.1.57264.1.6",
+
+  // Current issuer
+  issuerV2: "1.3.6.1.4.1.57264.1.8",
+
+  // Workflow identity
+  buildSignerUri: "1.3.6.1.4.1.57264.1.9",
+  buildSignerDigest: "1.3.6.1.4.1.57264.1.10",
+  runnerEnvironment: "1.3.6.1.4.1.57264.1.11",
+
+  // Source repository
+  sourceRepositoryUri: "1.3.6.1.4.1.57264.1.12",
+  sourceRepositoryDigest: "1.3.6.1.4.1.57264.1.13",
+  sourceRepositoryRef: "1.3.6.1.4.1.57264.1.14",
+  sourceRepositoryIdentifier: "1.3.6.1.4.1.57264.1.15",
+  sourceRepositoryOwnerUri: "1.3.6.1.4.1.57264.1.16",
+  sourceRepositoryOwnerIdentifier: "1.3.6.1.4.1.57264.1.17",
+
+  // Build config
+  buildConfigUri: "1.3.6.1.4.1.57264.1.18",
+  buildConfigDigest: "1.3.6.1.4.1.57264.1.19",
+
+  // Execution context
+  buildTrigger: "1.3.6.1.4.1.57264.1.20",
+  runInvocationUri: "1.3.6.1.4.1.57264.1.21",
+  sourceRepositoryVisibilityAtSigning: "1.3.6.1.4.1.57264.1.22",
+  deploymentEnvironment: "1.3.6.1.4.1.57264.1.23",
+} as const;
+
+type SigstoreClaimOption = { oid: string; value: string };
+
 type DeviceAuthResponse = {
   device_code: string;
   user_code: string;
@@ -83,6 +124,45 @@ async function writeMaybe(filePath: string | undefined, contents: string): Promi
 function collectSigner(value: string, previous: string[]): string[] {
   previous.push(value);
   return previous;
+}
+
+
+function collectClaim(value: string, previous: SigstoreClaimOption[]): SigstoreClaimOption[] {
+  const separatorIndex = value.indexOf("=");
+  if (separatorIndex <= 0) {
+    throw new Error("--claim values must be in OID=value format");
+  }
+  const oid = value.slice(0, separatorIndex).trim();
+  const claimValue = value.slice(separatorIndex + 1).trim();
+  if (!/^\d+(?:\.\d+)+$/.test(oid)) {
+    throw new Error(`--claim key must be an OID, got '${oid}'`);
+  }
+  if (!claimValue) {
+    throw new Error("--claim value must be non-empty");
+  }
+  previous.push({ oid, value: claimValue });
+  return previous;
+}
+
+function setClaim(
+  previous: SigstoreClaimOption[] | undefined,
+  oid: string,
+  value: string,
+): SigstoreClaimOption[] {
+  const claims = previous ?? [];
+  claims.push({ oid, value: value.trim() });
+  return claims;
+}
+
+function claimsToRecord(claims: SigstoreClaimOption[]): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const claim of claims) {
+    if (!claim.value) {
+      throw new Error(`claim value for OID '${claim.oid}' must be non-empty`);
+    }
+    record[claim.oid] = claim.value;
+  }
+  return record;
 }
 
 async function fetchSigstoreCommunityTrustedRoot(): Promise<string> {
@@ -285,8 +365,136 @@ enrollment
   .option("--type <type>", "Enrollment type (sigsum or sigstore)", "sigsum")
   .option("--trusted-root <path>", "Sigstore trusted root file")
   .option("--community-trusted-root", "Fetch the Sigstore community trusted root via TUF")
-  .option("--issuer <value>", "Sigstore issuer")
-  .option("--identity <value>", "Sigstore identity")
+  .option("--issuer <value>", "Sigstore issuer (maps to OID 1.3.6.1.4.1.57264.1.8)")
+  .option("--identity <value>", "Sigstore identity (maps to OID 2.5.29.17)")
+  .option("--claim <oid=value>", "Sigstore claim constraint by OID", collectClaim, [] as SigstoreClaimOption[])
+  .option(
+    "--subject-alt-name <value>",
+    "Sigstore claim OID 2.5.29.17 (Subject Alternative Name)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.subjectAltName, value),
+  )
+  .option(
+    "--issuer-v1 <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.1 (Fulcio Issuer V1)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.issuerV1, value),
+  )
+  .option(
+    "--issuer-v2 <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.8 (Fulcio Issuer V2)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.issuerV2, value),
+  )  
+  .option(
+    "--build-signer-uri <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.9",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildSignerUri, value),
+  )
+  .option(
+    "--build-signer-digest <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.10",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildSignerDigest, value),
+  )
+  .option(
+    "--runner-environment <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.11",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.runnerEnvironment, value),
+  )
+  .option(
+    "--source-repository-uri <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.12",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryUri, value),
+  )
+  .option(
+    "--source-repository-digest <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.13",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryDigest, value),
+  )
+  .option(
+    "--source-repository-ref <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.14",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryRef, value),
+  )
+  .option(
+    "--source-repository-identifier <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.15",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryIdentifier, value),
+  )
+  .option(
+    "--source-repository-owner-uri <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.16",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryOwnerUri, value),
+  )
+  .option(
+    "--source-repository-owner-identifier <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.17",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryOwnerIdentifier, value),
+  )
+  .option(
+    "--build-config-uri <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.18",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildConfigUri, value),
+  )
+  .option(
+    "--build-config-digest <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.19",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildConfigDigest, value),
+  )
+  .option(
+    "--build-trigger <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.20",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.buildTrigger, value),
+  )
+  .option(
+    "--run-invocation-uri <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.21",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.runInvocationUri, value),
+  )
+  .option(
+    "--source-repository-visibility-at-signing <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.22",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.sourceRepositoryVisibilityAtSigning, value),
+  )
+  .option(
+    "--deployment-environment <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.23",
+    (value: string, previous: SigstoreClaimOption[]) => setClaim(previous, SIGSTORE_CLAIM_OIDS.deploymentEnvironment, value),
+  )
+  .option(
+    "--workflow-trigger-legacy <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.2 (Legacy Workflow Trigger)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowTriggerLegacy, value),
+  )
+
+  .option(
+    "--workflow-sha-legacy <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.3 (Legacy Workflow SHA)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowShaLegacy, value),
+  )
+
+  .option(
+    "--workflow-name-legacy <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.4 (Legacy Workflow Name)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowNameLegacy, value),
+  )
+
+  .option(
+    "--workflow-repository-legacy <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.5 (Legacy Workflow Repository)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowRepositoryLegacy, value),
+  )
+
+  .option(
+    "--workflow-ref-legacy <value>",
+    "Sigstore claim OID 1.3.6.1.4.1.57264.1.6 (Legacy Workflow Ref)",
+    (value: string, previous: SigstoreClaimOption[]) =>
+      setClaim(previous, SIGSTORE_CLAIM_OIDS.workflowRefLegacy, value),
+  )
   .option("-o, --output <path>", "Write result to file instead of stdout")
   .action(async (options: {
     policyFile?: string;
@@ -299,6 +507,7 @@ enrollment
     communityTrustedRoot?: boolean;
     issuer?: string;
     identity?: string;
+    claim: SigstoreClaimOption[];
     output?: string;
   }) => {
     const enrollmentType = options.type ?? "sigsum";
@@ -352,14 +561,20 @@ enrollment
       if (!options.trustedRoot && !options.communityTrustedRoot) {
         throw new Error("--trusted-root or --community-trusted-root is required for sigstore enrollments");
       }
-      if (!options.issuer) {
-        throw new Error("--issuer is required for sigstore enrollments");
-      }
-      if (!options.identity) {
-        throw new Error("--identity is required for sigstore enrollments");
-      }
       if (!options.maxAge) {
         throw new Error("--max-age is required for sigstore enrollments");
+      }
+      const claims: SigstoreClaimOption[] = [...(options.claim ?? [])];
+      if (options.identity) {
+        setClaim(claims, SIGSTORE_CLAIM_OIDS.subjectAltName, options.identity);
+      }
+      if (options.issuer) {
+        setClaim(claims, SIGSTORE_CLAIM_OIDS.issuerV2, options.issuer);
+      }
+      if (claims.length === 0) {
+        throw new Error(
+          "at least one sigstore claim is required (use --claim and/or --identity/--issuer)",
+        );
       }
       let trustedRoot: Record<string, unknown>;
       if (options.communityTrustedRoot) {
@@ -380,8 +595,7 @@ enrollment
       enrollmentObject = buildEnrollmentObject({
         type: "sigstore",
         trustedRoot,
-        issuer: options.issuer,
-        identity: options.identity,
+        claims: claimsToRecord(claims),
         maxAge: options.maxAge,
       });
     }

--- a/src/enrollment.ts
+++ b/src/enrollment.ts
@@ -25,8 +25,7 @@ export interface SigsumEnrollmentInput {
 export interface SigstoreEnrollmentInput {
   type: "sigstore";
   trusted_root: Record<string, unknown>;
-  identity: string;
-  issuer: string;
+  claims: Record<string, string>;
   max_age: number;
 }
 
@@ -45,8 +44,7 @@ export interface SigsumEnrollmentOptions {
 export interface SigstoreEnrollmentOptions {
   type: "sigstore";
   trustedRoot: Record<string, unknown>;
-  identity: string;
-  issuer: string;
+  claims: Record<string, string>;
   maxAge: number | string;
 }
 
@@ -65,8 +63,7 @@ export function buildEnrollmentObject(options: EnrollmentOptions): EnrollmentInp
     return {
       type,
       trusted_root: ensureObject(sigstoreOptions.trustedRoot, "trusted_root"),
-      identity: ensureNonEmptyString(sigstoreOptions.identity, "identity"),
-      issuer: ensureNonEmptyString(sigstoreOptions.issuer, "issuer"),
+      claims: normalizeSigstoreClaims(sigstoreOptions.claims, "claims"),
       max_age: parsedMaxAge,
     };
   }
@@ -119,8 +116,7 @@ export function parseEnrollmentObject(parsed: any): EnrollmentInput {
     return {
       type: "sigstore",
       trusted_root: ensureObject(parsed.trusted_root, "enrollment.trusted_root"),
-      identity: ensureNonEmptyString(parsed.identity, "enrollment.identity"),
-      issuer: ensureNonEmptyString(parsed.issuer, "enrollment.issuer"),
+      claims: normalizeSigstoreClaims(parsed.claims, "enrollment.claims"),
       max_age: maxAge,
     };
   }
@@ -163,6 +159,19 @@ export function parseEnrollmentObject(parsed: any): EnrollmentInput {
     cas_url: parsed.cas_url,
     ...(normalizedLogs ? { logs: normalizedLogs } : {}),
   };
+}
+
+function normalizeSigstoreClaims(
+  value: unknown,
+  fieldName: string,
+): Record<string, string> {
+  const claims = ensureRecordOfStrings(value, fieldName);
+  for (const oid of Object.keys(claims)) {
+    if (!/^\d+(?:\.\d+)+$/.test(oid)) {
+      throw new Error(`${fieldName} keys must be valid OID strings`);
+    }
+  }
+  return claims;
 }
 
 export async function loadEnrollment(path: string): Promise<EnrollmentInput> {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -167,16 +167,20 @@ describe("enrollment helpers", () => {
     const enrollment = buildEnrollmentObject({
       type: "sigstore",
       trustedRoot,
-      issuer: "issuer.example",
-      identity: "identity@example.com",
+      claims: {
+        "2.5.29.17": "identity@example.com",
+        "1.3.6.1.4.1.57264.1.8": "issuer.example",
+      },
       maxAge: 1_000_000,
     });
 
     expect(enrollment).toEqual({
       type: "sigstore",
       trusted_root: trustedRoot,
-      identity: "identity@example.com",
-      issuer: "issuer.example",
+      claims: {
+        "2.5.29.17": "identity@example.com",
+        "1.3.6.1.4.1.57264.1.8": "issuer.example",
+      },
       max_age: 1_000_000,
     });
   });
@@ -236,11 +240,19 @@ describe("enrollment helpers", () => {
       parseEnrollmentObject({
         type: "sigstore",
         trusted_root: "",
-        identity: "id",
-        issuer: "issuer",
+        claims: { "2.5.29.17": "id" },
         max_age: 1_000_000,
       }),
     ).toThrow("enrollment.trusted_root must be an object");
+
+    expect(() =>
+      parseEnrollmentObject({
+        type: "sigstore",
+        trusted_root: {},
+        claims: { not_oid: "id" },
+        max_age: 1_000_000,
+      }),
+    ).toThrow("enrollment.claims keys must be valid OID strings");
   });
 });
 


### PR DESCRIPTION
See https://github.com/freedomofpress/webcat/pull/108

Adds to the command line the possibility to add free custom claims in the format `--claim oid=value` but also provides friendly commands for the known Sigstore ones. Keeps `--identity` and `--issuer`  but transforms them into OID claims.


```
Usage: webcat-cli enrollment create [options]

Create an enrollment definition

Options:
  -p, --policy-file <path>                           Sigsum policy file to compile
  -s, --signer <key>                                 Signer public key (hex or base64) (default: [])
  -t, --threshold <k>                                Threshold for signature approval
  -m, --max-age <seconds>                            Maximum age in seconds
  -c, --cas-url <url>                                CAS https URL
  --type <type>                                      Enrollment type (sigsum or sigstore) (default: "sigsum")
  --trusted-root <path>                              Sigstore trusted root file
  --community-trusted-root                           Fetch the Sigstore community trusted root via TUF
  --issuer <value>                                   Sigstore issuer (maps to OID 1.3.6.1.4.1.57264.1.8)
  --identity <value>                                 Sigstore identity (maps to OID 2.5.29.17)
  --claim <oid=value>                                Sigstore claim constraint by OID (default: [])
  --subject-alt-name <value>                         Sigstore claim OID 2.5.29.17 (Subject Alternative Name)
  --issuer-v1 <value>                                Sigstore claim OID 1.3.6.1.4.1.57264.1.1 (Fulcio Issuer V1)
  --issuer-v2 <value>                                Sigstore claim OID 1.3.6.1.4.1.57264.1.8 (Fulcio Issuer V2)
  --build-signer-uri <value>                         Sigstore claim OID 1.3.6.1.4.1.57264.1.9
  --build-signer-digest <value>                      Sigstore claim OID 1.3.6.1.4.1.57264.1.10
  --runner-environment <value>                       Sigstore claim OID 1.3.6.1.4.1.57264.1.11
  --source-repository-uri <value>                    Sigstore claim OID 1.3.6.1.4.1.57264.1.12
  --source-repository-digest <value>                 Sigstore claim OID 1.3.6.1.4.1.57264.1.13
  --source-repository-ref <value>                    Sigstore claim OID 1.3.6.1.4.1.57264.1.14
  --source-repository-identifier <value>             Sigstore claim OID 1.3.6.1.4.1.57264.1.15
  --source-repository-owner-uri <value>              Sigstore claim OID 1.3.6.1.4.1.57264.1.16
  --source-repository-owner-identifier <value>       Sigstore claim OID 1.3.6.1.4.1.57264.1.17
  --build-config-uri <value>                         Sigstore claim OID 1.3.6.1.4.1.57264.1.18
  --build-config-digest <value>                      Sigstore claim OID 1.3.6.1.4.1.57264.1.19
  --build-trigger <value>                            Sigstore claim OID 1.3.6.1.4.1.57264.1.20
  --run-invocation-uri <value>                       Sigstore claim OID 1.3.6.1.4.1.57264.1.21
  --source-repository-visibility-at-signing <value>  Sigstore claim OID 1.3.6.1.4.1.57264.1.22
  --deployment-environment <value>                   Sigstore claim OID 1.3.6.1.4.1.57264.1.23
  --workflow-trigger-legacy <value>                  Sigstore claim OID 1.3.6.1.4.1.57264.1.2 (Legacy Workflow Trigger)
  --workflow-sha-legacy <value>                      Sigstore claim OID 1.3.6.1.4.1.57264.1.3 (Legacy Workflow SHA)
  --workflow-name-legacy <value>                     Sigstore claim OID 1.3.6.1.4.1.57264.1.4 (Legacy Workflow Name)
  --workflow-repository-legacy <value>               Sigstore claim OID 1.3.6.1.4.1.57264.1.5 (Legacy Workflow Repository)
  --workflow-ref-legacy <value>                      Sigstore claim OID 1.3.6.1.4.1.57264.1.6 (Legacy Workflow Ref)
  -o, --output <path>                                Write result to file instead of stdout
  -h, --help                                         display help for command

```

Github Actions changes still TODO. The goal there would be to also have the signing one reusable.