### PR TITLE
Add support for Sigsum's domain-based rate limiting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -634,6 +634,8 @@ manifest
   .requiredOption("-i, --input <path>", "Manifest file to sign")
   .option("-p, --policy-file <path>", "Sigsum trust policy file for sigsum-submit")
   .option("-k, --key <path>", "Sigsum private key for signing")
+  .option("--token-signing-key <path>", "Sigsum private key for token signing")
+  .option("--token-domain <domain>", "Domain name to use for Sigsum rate limiting")
   .option(
     "--bundle-type <type>",
     "Sigstore bundle type to generate (message or dsse)",
@@ -656,6 +658,8 @@ manifest
       input: string;
       policyFile?: string;
       key?: string;
+      tokenSigningKey?: string;
+      tokenDomain?: string;
       bundleType?: string;
       fulcioUrl?: string;
       rekorUrl?: string;
@@ -698,7 +702,13 @@ manifest
         const tempFile = path.join(tempDir, "manifest.json");
         try {
           await writeFile(tempFile, canonicalManifest);
-          await runSigsumSubmit(options.policyFile, options.key, tempFile);
+          await runSigsumSubmit(
+            options.policyFile,
+            options.key,
+            tempFile,
+            options.tokenSigningKey,
+            options.tokenDomain,
+          );
           const proofPath = `${tempFile}.proof`;
           let proofText: string;
           try {

--- a/src/sigsum.ts
+++ b/src/sigsum.ts
@@ -54,9 +54,22 @@ export async function deriveSignerKeyFromPrivateKey(privKeyPath: string): Promis
   return hexToBase64Url(hex);
 }
 
-export async function runSigsumSubmit(policyPath: string, keyPath: string, payloadPath: string): Promise<void> {
+export async function runSigsumSubmit(
+  policyPath: string,
+  keyPath: string,
+  payloadPath: string,
+  tokenSigningKey?: string,
+  tokenDomain?: string,
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn("sigsum-submit", ["-p", policyPath, "-k", keyPath, payloadPath], {
+    const child = spawn("sigsum-submit", [
+      "-p", policyPath, "-k", keyPath,
+      ...(tokenDomain && tokenSigningKey ? [
+        "-a", tokenSigningKey,
+        "-d", tokenDomain,
+      ] : []),
+      payloadPath,
+    ], {
       stdio: "inherit",
     });
     child.on("error", (err: NodeJS.ErrnoException) => {


### PR DESCRIPTION
The Sigsum log server protocol has an [optional rate limiting feature](https://git.glasklar.is/sigsum/project/documentation/-/blob/main/log.md#4--rate-limiting) that's implemented by all public production logs. This PR adds support for the feature in `webcat-cli` through two new options for the `webcat manifest sign` command:

```
  --token-signing-key <path>  Sigsum private key for token signing
  --token-domain <domain>     Domain name to use for Sigsum rate limiting
```